### PR TITLE
Add kmsg CLI tool for KakaoTalk on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "59f4178870c50ff16edc7d3be87a42d2a17eef47a3bca1126d41491929baa8b8",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "kmsg",
+    platforms: [
+        .macOS(.v13)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "kmsg",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# kmsg
+
+A CLI tool for KakaoTalk on macOS using Accessibility APIs.
+
+## Features
+
+- Check KakaoTalk status
+- Inspect UI hierarchy for debugging
+- List chat rooms
+- Send messages
+- Read messages
+
+## Requirements
+
+- macOS 13.0+
+- KakaoTalk for Mac
+- Accessibility permission granted
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/channprj/kmsg.git
+cd kmsg
+
+# Build
+swift build -c release
+
+# Install (optional)
+cp .build/release/kmsg /usr/local/bin/
+```
+
+## Usage
+
+### Check Status
+
+```bash
+kmsg status
+kmsg status --verbose
+```
+
+### Inspect UI
+
+```bash
+# Inspect main window
+kmsg inspect
+
+# Inspect specific window with more depth
+kmsg inspect --window 1 --depth 5
+
+# Show all attributes
+kmsg inspect --show-attributes
+```
+
+### List Chats
+
+```bash
+kmsg chats
+kmsg chats --verbose
+```
+
+### Send Message
+
+```bash
+kmsg send "Friend Name" "Hello!"
+kmsg send "Chat Room" "Message" --dry-run
+```
+
+### Read Messages
+
+```bash
+kmsg read "Chat Name"
+kmsg read "Chat Name" --limit 50
+```
+
+## Permissions
+
+This tool requires Accessibility permission to control KakaoTalk:
+
+1. Open **System Settings** > **Privacy & Security** > **Accessibility**
+2. Click the **+** button
+3. Navigate to and select the `kmsg` binary
+4. Enable the toggle for `kmsg`
+
+## How It Works
+
+kmsg uses macOS Accessibility APIs (`AXUIElement`) to interact with KakaoTalk's user interface. This approach:
+
+- Doesn't require reverse engineering KakaoTalk protocols
+- Doesn't violate KakaoTalk's terms of service
+- Works with the official KakaoTalk for Mac app
+- Is safe and respects user privacy
+
+## License
+
+MIT License - See [LICENSE](LICENSE) for details.

--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -1,0 +1,54 @@
+# kmsg - KakaoTalk CLI Tool
+
+## Current Status
+
+Basic project structure is complete with working CLI commands:
+
+- `kmsg status` - Check accessibility and KakaoTalk status ✓
+- `kmsg inspect` - Inspect UI hierarchy ✓
+- `kmsg chats` - List chats (basic implementation)
+- `kmsg send` - Send message (basic implementation)
+- `kmsg read` - Read messages (basic implementation)
+
+Build: `swift build`
+Run: `.build/debug/kmsg`
+
+## KakaoTalk UI Structure (discovered via inspect)
+
+Main window (`id: Main Window`):
+- Navigation buttons: `id: friends`, `id: chatrooms`, `id: more`
+- Unread count: `AXStaticText` with value like "999+"
+- Content area: `AXScrollArea > AXTable > AXRow > AXCell`
+
+Chat window (e.g., `title: "인호 원일 요섭 재균"`):
+- Messages: `AXScrollArea > AXTable > AXRow` structure
+- Input: Look for `AXTextArea` or `AXTextField`
+
+## Next Steps
+
+1. **Improve chat list parsing** - Extract chat names from AXCell children
+2. **Add friends command** - List friends from friends tab
+3. **Improve message reading** - Parse actual message content from rows
+4. **Test send command** - Verify keyboard input works for Korean text
+5. **Add open command** - Open a specific chat by name/search
+6. **Error handling** - Better feedback when elements not found
+
+## Technical Notes
+
+- Uses macOS Accessibility APIs (AXUIElement)
+- Requires Accessibility permission in System Settings
+- KakaoTalk bundle ID: `com.kakao.KakaoTalkMac`
+- Keyboard input uses CGEvent for Korean text support
+
+## Testing
+
+```bash
+# Check status
+.build/debug/kmsg status --verbose
+
+# Inspect UI (very useful for debugging)
+.build/debug/kmsg inspect --depth 5 --window 1
+
+# With attributes
+.build/debug/kmsg inspect --depth 3 --show-attributes
+```

--- a/Sources/kmsg/Accessibility/AXConstants.swift
+++ b/Sources/kmsg/Accessibility/AXConstants.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// AX Role constants used throughout the application
+// These are the string values for common accessibility roles
+
+public let kAXStaticTextRole = "AXStaticText"
+public let kAXTextFieldRole = "AXTextField"
+public let kAXTextAreaRole = "AXTextArea"
+public let kAXButtonRole = "AXButton"
+public let kAXTableRole = "AXTable"
+public let kAXRowRole = "AXRow"
+public let kAXCellRole = "AXCell"
+public let kAXListRole = "AXList"
+public let kAXOutlineRole = "AXOutline"
+public let kAXGroupRole = "AXGroup"
+public let kAXScrollAreaRole = "AXScrollArea"
+public let kAXWindowRole = "AXWindow"
+public let kAXApplicationRole = "AXApplication"
+public let kAXImageRole = "AXImage"
+public let kAXToolbarRole = "AXToolbar"
+public let kAXMenuRole = "AXMenu"
+public let kAXMenuItemRole = "AXMenuItem"
+public let kAXPopUpButtonRole = "AXPopUpButton"
+public let kAXCheckBoxRole = "AXCheckBox"
+public let kAXRadioButtonRole = "AXRadioButton"
+public let kAXTabGroupRole = "AXTabGroup"
+public let kAXSplitGroupRole = "AXSplitGroup"
+public let kAXScrollBarRole = "AXScrollBar"
+public let kAXWebAreaRole = "AXWebArea"

--- a/Sources/kmsg/Accessibility/AXError+Extension.swift
+++ b/Sources/kmsg/Accessibility/AXError+Extension.swift
@@ -1,0 +1,59 @@
+import ApplicationServices.HIServices
+
+/// Provides a human-readable description for AXError codes
+public func describeAXError(_ error: AXError) -> String {
+    switch error {
+    case .success:
+        return "Success"
+    case .failure:
+        return "Generic failure"
+    case .illegalArgument:
+        return "Illegal argument"
+    case .invalidUIElement:
+        return "Invalid UI element"
+    case .invalidUIElementObserver:
+        return "Invalid UI element observer"
+    case .cannotComplete:
+        return "Cannot complete (app may have terminated)"
+    case .attributeUnsupported:
+        return "Attribute unsupported"
+    case .actionUnsupported:
+        return "Action unsupported"
+    case .notificationUnsupported:
+        return "Notification unsupported"
+    case .notImplemented:
+        return "Not implemented"
+    case .notificationAlreadyRegistered:
+        return "Notification already registered"
+    case .notificationNotRegistered:
+        return "Notification not registered"
+    case .apiDisabled:
+        return "Accessibility API disabled"
+    case .noValue:
+        return "No value"
+    case .parameterizedAttributeUnsupported:
+        return "Parameterized attribute unsupported"
+    case .notEnoughPrecision:
+        return "Not enough precision"
+    @unknown default:
+        return "Unknown error (code: \(error.rawValue))"
+    }
+}
+
+/// Custom error type for Accessibility operations
+public enum AccessibilityError: Error, CustomStringConvertible {
+    case axError(AXError)
+    case typeMismatch
+    case noValue
+
+    public var description: String {
+        switch self {
+        case .axError(let error):
+            return describeAXError(error)
+        case .typeMismatch:
+            return "Type mismatch"
+        case .noValue:
+            return "No value"
+        }
+    }
+}

--- a/Sources/kmsg/Accessibility/AccessibilityPermission.swift
+++ b/Sources/kmsg/Accessibility/AccessibilityPermission.swift
@@ -1,0 +1,35 @@
+import ApplicationServices.HIServices
+import Foundation
+
+/// Handles macOS Accessibility permission checking and requesting
+public enum AccessibilityPermission {
+    /// Check if the app has accessibility permissions
+    public static func isGranted() -> Bool {
+        AXIsProcessTrusted()
+    }
+
+    /// Prompt user to grant accessibility permissions if not already granted
+    /// Returns true if permissions are already granted
+    @discardableResult
+    public static func requestIfNeeded() -> Bool {
+        let key = "AXTrustedCheckOptionPrompt" as CFString
+        let options = [key: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    /// Print instructions for granting accessibility permissions
+    public static func printInstructions() {
+        print("""
+        ⚠️  Accessibility permission required!
+
+        To use kmsg, you need to grant Accessibility permissions:
+
+        1. Open System Settings > Privacy & Security > Accessibility
+        2. Click the '+' button
+        3. Navigate to and select the kmsg binary
+        4. Enable the toggle for kmsg
+
+        Alternatively, run: sudo kmsg --request-permission
+        """)
+    }
+}

--- a/Sources/kmsg/Accessibility/UIElement.swift
+++ b/Sources/kmsg/Accessibility/UIElement.swift
@@ -1,0 +1,284 @@
+import ApplicationServices.HIServices
+import Foundation
+
+/// A wrapper around AXUIElement providing a Swift-friendly API
+public final class UIElement: @unchecked Sendable {
+    public let axElement: AXUIElement
+
+    public init(_ axElement: AXUIElement) {
+        self.axElement = axElement
+    }
+
+    // MARK: - Factory Methods
+
+    /// Get the system-wide UI element
+    public static func systemWide() -> UIElement {
+        UIElement(AXUIElementCreateSystemWide())
+    }
+
+    /// Create a UI element for an application with the given PID
+    public static func application(pid: pid_t) -> UIElement {
+        UIElement(AXUIElementCreateApplication(pid))
+    }
+
+    // MARK: - Attributes
+
+    /// Get an attribute value
+    public func attribute<T>(_ name: String) throws -> T {
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(axElement, name as CFString, &value)
+        guard error == .success else {
+            throw AccessibilityError.axError(error)
+        }
+        guard let typedValue = value as? T else {
+            throw AccessibilityError.typeMismatch
+        }
+        return typedValue
+    }
+
+    /// Get an optional attribute value (returns nil instead of throwing for .noValue)
+    public func attributeOptional<T>(_ name: String) -> T? {
+        try? attribute(name)
+    }
+
+    /// Set an attribute value
+    public func setAttribute(_ name: String, value: CFTypeRef) throws {
+        let error = AXUIElementSetAttributeValue(axElement, name as CFString, value)
+        guard error == .success else {
+            throw AccessibilityError.axError(error)
+        }
+    }
+
+    /// Get all attribute names
+    public func attributeNames() throws -> [String] {
+        var names: CFArray?
+        let error = AXUIElementCopyAttributeNames(axElement, &names)
+        guard error == .success else {
+            throw AccessibilityError.axError(error)
+        }
+        return names as? [String] ?? []
+    }
+
+    // MARK: - Common Attributes
+
+    public var role: String? {
+        attributeOptional(kAXRoleAttribute)
+    }
+
+    public var roleDescription: String? {
+        attributeOptional(kAXRoleDescriptionAttribute)
+    }
+
+    public var title: String? {
+        attributeOptional(kAXTitleAttribute)
+    }
+
+    public var value: Any? {
+        attributeOptional(kAXValueAttribute)
+    }
+
+    public var stringValue: String? {
+        attributeOptional(kAXValueAttribute)
+    }
+
+    public var axDescription: String? {
+        attributeOptional(kAXDescriptionAttribute)
+    }
+
+    public var identifier: String? {
+        attributeOptional(kAXIdentifierAttribute)
+    }
+
+    public var isEnabled: Bool {
+        attributeOptional(kAXEnabledAttribute) ?? false
+    }
+
+    public var isFocused: Bool {
+        attributeOptional(kAXFocusedAttribute) ?? false
+    }
+
+    public var position: CGPoint? {
+        guard let axValue: AXValue = attributeOptional(kAXPositionAttribute) else {
+            return nil
+        }
+        var point = CGPoint.zero
+        guard AXValueGetValue(axValue, .cgPoint, &point) else {
+            return nil
+        }
+        return point
+    }
+
+    public var size: CGSize? {
+        guard let axValue: AXValue = attributeOptional(kAXSizeAttribute) else {
+            return nil
+        }
+        var size = CGSize.zero
+        guard AXValueGetValue(axValue, .cgSize, &size) else {
+            return nil
+        }
+        return size
+    }
+
+    public var frame: CGRect? {
+        guard let pos = position, let size = size else {
+            return nil
+        }
+        return CGRect(origin: pos, size: size)
+    }
+
+    // MARK: - Hierarchy
+
+    public var parent: UIElement? {
+        guard let axParent: AXUIElement = attributeOptional(kAXParentAttribute) else {
+            return nil
+        }
+        return UIElement(axParent)
+    }
+
+    public var children: [UIElement] {
+        guard let axChildren: [AXUIElement] = attributeOptional(kAXChildrenAttribute) else {
+            return []
+        }
+        return axChildren.map { UIElement($0) }
+    }
+
+    public var windows: [UIElement] {
+        guard let axWindows: [AXUIElement] = attributeOptional(kAXWindowsAttribute) else {
+            return []
+        }
+        return axWindows.map { UIElement($0) }
+    }
+
+    public var focusedWindow: UIElement? {
+        guard let axWindow: AXUIElement = attributeOptional(kAXFocusedWindowAttribute) else {
+            return nil
+        }
+        return UIElement(axWindow)
+    }
+
+    public var mainWindow: UIElement? {
+        guard let axWindow: AXUIElement = attributeOptional(kAXMainWindowAttribute) else {
+            return nil
+        }
+        return UIElement(axWindow)
+    }
+
+    // MARK: - Actions
+
+    /// Get all available actions
+    public func actionNames() throws -> [String] {
+        var names: CFArray?
+        let error = AXUIElementCopyActionNames(axElement, &names)
+        guard error == .success else {
+            throw AccessibilityError.axError(error)
+        }
+        return names as? [String] ?? []
+    }
+
+    /// Perform an action
+    public func performAction(_ action: String) throws {
+        let error = AXUIElementPerformAction(axElement, action as CFString)
+        guard error == .success else {
+            throw AccessibilityError.axError(error)
+        }
+    }
+
+    /// Press (equivalent to AXPress action)
+    public func press() throws {
+        try performAction(kAXPressAction)
+    }
+
+    /// Set focus
+    public func focus() throws {
+        try setAttribute(kAXFocusedAttribute, value: true as CFBoolean)
+    }
+
+    // MARK: - Element at Point
+
+    /// Get the element at the specified screen position
+    public func element(at point: CGPoint) throws -> UIElement {
+        var element: AXUIElement?
+        let error = AXUIElementCopyElementAtPosition(axElement, Float(point.x), Float(point.y), &element)
+        guard error == .success, let el = element else {
+            throw AccessibilityError.axError(error)
+        }
+        return UIElement(el)
+    }
+
+    // MARK: - Search
+
+    /// Find all descendants matching a predicate (breadth-first search)
+    public func findAll(where predicate: (UIElement) -> Bool) -> [UIElement] {
+        var results: [UIElement] = []
+        var queue = children
+
+        while !queue.isEmpty {
+            let current = queue.removeFirst()
+            if predicate(current) {
+                results.append(current)
+            }
+            queue.append(contentsOf: current.children)
+        }
+
+        return results
+    }
+
+    /// Find first descendant matching a predicate (breadth-first search)
+    public func findFirst(where predicate: (UIElement) -> Bool) -> UIElement? {
+        var queue = children
+
+        while !queue.isEmpty {
+            let current = queue.removeFirst()
+            if predicate(current) {
+                return current
+            }
+            queue.append(contentsOf: current.children)
+        }
+
+        return nil
+    }
+
+    /// Find elements by role
+    public func findAll(role: String) -> [UIElement] {
+        findAll { $0.role == role }
+    }
+
+    /// Find element by identifier
+    public func findFirst(identifier: String) -> UIElement? {
+        findFirst { $0.identifier == identifier }
+    }
+
+    /// Find element by title
+    public func findFirst(title: String) -> UIElement? {
+        findFirst { $0.title == title }
+    }
+
+    /// Find element by title containing substring
+    public func findFirst(titleContaining substring: String) -> UIElement? {
+        findFirst { $0.title?.contains(substring) == true }
+    }
+}
+
+// MARK: - Debug
+
+extension UIElement: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var parts: [String] = []
+
+        if let role = role {
+            parts.append("role: \(role)")
+        }
+        if let title = title {
+            parts.append("title: \"\(title)\"")
+        }
+        if let identifier = identifier {
+            parts.append("id: \(identifier)")
+        }
+        if let value = stringValue {
+            let truncated = value.count > 50 ? String(value.prefix(50)) + "..." : value
+            parts.append("value: \"\(truncated)\"")
+        }
+
+        return "UIElement(\(parts.joined(separator: ", ")))"
+    }
+}

--- a/Sources/kmsg/Commands/ChatsCommand.swift
+++ b/Sources/kmsg/Commands/ChatsCommand.swift
@@ -1,0 +1,115 @@
+import ArgumentParser
+import Foundation
+
+struct ChatsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "chats",
+        abstract: "List chat rooms"
+    )
+
+    @Flag(name: .shortAndLong, help: "Show detailed information")
+    var verbose: Bool = false
+
+    @Option(name: .shortAndLong, help: "Maximum number of chats to show")
+    var limit: Int = 20
+
+    func run() throws {
+        guard AccessibilityPermission.isGranted() else {
+            AccessibilityPermission.printInstructions()
+            throw ExitCode.failure
+        }
+
+        let kakao = try KakaoTalkApp()
+
+        // Activate KakaoTalk to ensure UI is accessible
+        kakao.activate()
+
+        // Give the app a moment to become active
+        Thread.sleep(forTimeInterval: 0.2)
+
+        // Try to find the chat list
+        // KakaoTalk's chat list is typically in a table or list view
+        guard let mainWindow = kakao.mainWindow else {
+            print("Could not find KakaoTalk main window.")
+            print("Make sure KakaoTalk is open and visible.")
+            throw ExitCode.failure
+        }
+
+        print("Searching for chat list in KakaoTalk...\n")
+
+        // Find elements that might be chat list items
+        // Common roles: AXRow, AXCell, AXStaticText in a table/outline view
+        let tables = mainWindow.findAll(role: kAXTableRole)
+        let outlines = mainWindow.findAll(role: kAXOutlineRole)
+        let lists = mainWindow.findAll(role: kAXListRole)
+
+        var chatItems: [UIElement] = []
+
+        // Check tables for rows
+        for table in tables {
+            let rows = table.findAll(role: kAXRowRole)
+            chatItems.append(contentsOf: rows)
+        }
+
+        // Check outlines for rows
+        for outline in outlines {
+            let rows = outline.findAll(role: kAXRowRole)
+            chatItems.append(contentsOf: rows)
+        }
+
+        // Check lists for items
+        for list in lists {
+            let items = list.children
+            chatItems.append(contentsOf: items)
+        }
+
+        if chatItems.isEmpty {
+            print("No chat list found.")
+            print("\nTip: Make sure you're on the 'Chats' (채팅) tab in KakaoTalk.")
+            print("Use 'kmsg inspect' to explore the UI structure.")
+            return
+        }
+
+        print("Found \(min(chatItems.count, limit)) chat(s):\n")
+
+        for (index, item) in chatItems.prefix(limit).enumerated() {
+            let title = extractChatTitle(from: item)
+            let lastMessage = extractLastMessage(from: item)
+
+            print("[\(index + 1)] \(title)")
+            if verbose, let msg = lastMessage {
+                print("    └─ \(msg)")
+            }
+        }
+
+        if chatItems.count > limit {
+            print("\n... and \(chatItems.count - limit) more chats")
+        }
+    }
+
+    private func extractChatTitle(from element: UIElement) -> String {
+        // Try to find the chat name from various possible locations
+        if let title = element.title, !title.isEmpty {
+            return title
+        }
+
+        // Look for static text elements that might contain the name
+        let staticTexts = element.findAll(role: kAXStaticTextRole)
+        for text in staticTexts {
+            if let value = text.stringValue, !value.isEmpty {
+                return value
+            }
+        }
+
+        return "(Unknown Chat)"
+    }
+
+    private func extractLastMessage(from element: UIElement) -> String? {
+        // Find additional static text that might be the last message
+        let staticTexts = element.findAll(role: kAXStaticTextRole)
+        if staticTexts.count > 1 {
+            return staticTexts[1].stringValue
+        }
+        return nil
+    }
+}

--- a/Sources/kmsg/Commands/InspectCommand.swift
+++ b/Sources/kmsg/Commands/InspectCommand.swift
@@ -1,0 +1,100 @@
+import ArgumentParser
+import Foundation
+
+struct InspectCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "inspect",
+        abstract: "Inspect KakaoTalk UI hierarchy for debugging"
+    )
+
+    @Option(name: .shortAndLong, help: "Maximum depth to traverse")
+    var depth: Int = 4
+
+    @Option(name: .shortAndLong, help: "Window index to inspect (default: main window)")
+    var window: Int?
+
+    @Flag(name: .long, help: "Show all attributes for each element")
+    var showAttributes: Bool = false
+
+    func run() throws {
+        guard AccessibilityPermission.isGranted() else {
+            AccessibilityPermission.printInstructions()
+            throw ExitCode.failure
+        }
+
+        let kakao = try KakaoTalkApp()
+        let windows = kakao.windows
+
+        guard !windows.isEmpty else {
+            print("No KakaoTalk windows found.")
+            throw ExitCode.failure
+        }
+
+        let targetWindow: UIElement
+        if let windowIndex = window {
+            guard windowIndex >= 0 && windowIndex < windows.count else {
+                print("Invalid window index. Available windows: 0-\(windows.count - 1)")
+                throw ExitCode.failure
+            }
+            targetWindow = windows[windowIndex]
+        } else {
+            targetWindow = kakao.mainWindow ?? windows[0]
+        }
+
+        let windowTitle = targetWindow.title ?? "(untitled)"
+        print("Inspecting window: \(windowTitle)\n")
+
+        printElement(targetWindow, depth: 0, maxDepth: depth)
+    }
+
+    private func printElement(_ element: UIElement, depth: Int, maxDepth: Int) {
+        guard depth <= maxDepth else {
+            let childCount = element.children.count
+            if childCount > 0 {
+                let indent = String(repeating: "  ", count: depth)
+                print("\(indent)... (\(childCount) more children)")
+            }
+            return
+        }
+
+        let indent = String(repeating: "  ", count: depth)
+        var info: [String] = []
+
+        if let role = element.role {
+            info.append("role: \(role)")
+        }
+        if let title = element.title, !title.isEmpty {
+            info.append("title: \"\(title.prefix(40))\(title.count > 40 ? "..." : "")\"")
+        }
+        if let identifier = element.identifier, !identifier.isEmpty {
+            info.append("id: \(identifier)")
+        }
+        if let value = element.stringValue, !value.isEmpty {
+            let truncated = value.prefix(30)
+            info.append("value: \"\(truncated)\(value.count > 30 ? "..." : "")\"")
+        }
+        if element.isFocused {
+            info.append("focused")
+        }
+
+        print("\(indent)[\(info.joined(separator: ", "))]")
+
+        if showAttributes {
+            do {
+                let attrs = try element.attributeNames()
+                let attrIndent = indent + "  "
+                for attr in attrs.prefix(20) {
+                    if let val: Any = element.attributeOptional(attr) {
+                        print("\(attrIndent)\(attr) = \(String(describing: val).prefix(50))")
+                    }
+                }
+            } catch {
+                // Ignore attribute errors
+            }
+        }
+
+        for child in element.children {
+            printElement(child, depth: depth + 1, maxDepth: maxDepth)
+        }
+    }
+}

--- a/Sources/kmsg/Commands/ReadCommand.swift
+++ b/Sources/kmsg/Commands/ReadCommand.swift
@@ -1,0 +1,113 @@
+import ArgumentParser
+import Foundation
+
+struct ReadCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Read messages from a chat"
+    )
+
+    @Argument(help: "Name of the chat to read from (partial match supported)")
+    var chat: String
+
+    @Option(name: .shortAndLong, help: "Maximum number of messages to show")
+    var limit: Int = 20
+
+    @Flag(name: .long, help: "Show raw element info for debugging")
+    var debug: Bool = false
+
+    func run() throws {
+        guard AccessibilityPermission.isGranted() else {
+            AccessibilityPermission.printInstructions()
+            throw ExitCode.failure
+        }
+
+        let kakao = try KakaoTalkApp()
+        kakao.activate()
+        Thread.sleep(forTimeInterval: 0.2)
+
+        // Find the chat window
+        let chatWindow = kakao.windows.first { window in
+            window.title?.localizedCaseInsensitiveContains(chat) == true
+        }
+
+        guard let window = chatWindow else {
+            print("No chat window found for '\(chat)'")
+            print("\nAvailable windows:")
+            for (index, w) in kakao.windows.enumerated() {
+                print("  [\(index)] \(w.title ?? "(untitled)")")
+            }
+            print("\nTip: Open the chat you want to read first.")
+            throw ExitCode.failure
+        }
+
+        let windowTitle = window.title ?? chat
+        print("Reading messages from: \(windowTitle)\n")
+
+        // Find message elements
+        // Messages are typically in a scroll area or list
+        let scrollAreas = window.findAll(role: kAXScrollAreaRole)
+        let groups = window.findAll(role: kAXGroupRole)
+
+        var messageElements: [UIElement] = []
+
+        // Look for message containers
+        for scrollArea in scrollAreas {
+            // Messages might be in groups or static text elements
+            let texts = scrollArea.findAll(role: kAXStaticTextRole)
+            let msgGroups = scrollArea.findAll(role: kAXGroupRole)
+
+            messageElements.append(contentsOf: texts)
+            messageElements.append(contentsOf: msgGroups)
+        }
+
+        // Also check groups directly
+        for group in groups {
+            let texts = group.findAll(role: kAXStaticTextRole)
+            messageElements.append(contentsOf: texts)
+        }
+
+        if messageElements.isEmpty {
+            print("No messages found in this chat.")
+            print("Use 'kmsg inspect --window <n>' to explore the window structure.")
+            return
+        }
+
+        // Extract and display messages
+        var messages: [(sender: String?, text: String)] = []
+
+        for element in messageElements {
+            if let text = element.stringValue, !text.isEmpty {
+                // Try to determine if this is a sender name or message
+                // This heuristic may need adjustment based on actual KakaoTalk structure
+                messages.append((sender: nil, text: text))
+            }
+        }
+
+        // Remove duplicates and limit
+        var seen = Set<String>()
+        let uniqueMessages = messages.filter { msg in
+            let key = msg.text
+            if seen.contains(key) { return false }
+            seen.insert(key)
+            return true
+        }
+
+        let displayMessages = Array(uniqueMessages.suffix(limit))
+
+        print("Recent messages (\(displayMessages.count)):\n")
+
+        for (index, msg) in displayMessages.enumerated() {
+            if debug {
+                print("[\(index + 1)] \(msg.text)")
+            } else {
+                // Clean up and format the message
+                let cleanText = msg.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !cleanText.isEmpty {
+                    print("\(cleanText)")
+                    print("")
+                }
+            }
+        }
+    }
+}

--- a/Sources/kmsg/Commands/SendCommand.swift
+++ b/Sources/kmsg/Commands/SendCommand.swift
@@ -1,0 +1,126 @@
+import ArgumentParser
+import AppKit
+import Foundation
+
+struct SendCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "send",
+        abstract: "Send a message to a chat"
+    )
+
+    @Argument(help: "Name of the chat or friend to send to")
+    var recipient: String
+
+    @Argument(help: "Message to send")
+    var message: String
+
+    @Flag(name: .long, help: "Don't actually send, just show what would happen")
+    var dryRun: Bool = false
+
+    func run() throws {
+        guard AccessibilityPermission.isGranted() else {
+            AccessibilityPermission.printInstructions()
+            throw ExitCode.failure
+        }
+
+        let kakao = try KakaoTalkApp()
+
+        if dryRun {
+            print("Dry run mode - no message will be sent")
+            print("Recipient: \(recipient)")
+            print("Message: \(message)")
+            return
+        }
+
+        kakao.activate()
+        Thread.sleep(forTimeInterval: 0.3)
+
+        // Find or open the chat window for the recipient
+        print("Looking for chat with '\(recipient)'...")
+
+        // First, try to find an existing chat window with this recipient
+        let chatWindow = kakao.windows.first { window in
+            window.title?.contains(recipient) == true
+        }
+
+        if let window = chatWindow {
+            print("Found existing chat window.")
+            try sendMessageToWindow(window)
+        } else {
+            print("No existing chat window found.")
+            print("Please open a chat with '\(recipient)' first, or use the full window title.")
+            print("\nAvailable windows:")
+            for (index, window) in kakao.windows.enumerated() {
+                print("  [\(index)] \(window.title ?? "(untitled)")")
+            }
+            throw ExitCode.failure
+        }
+    }
+
+    private func sendMessageToWindow(_ window: UIElement) throws {
+        // Find the text input field
+        // This is typically an AXTextArea or AXTextField at the bottom of the chat window
+        let textAreas = window.findAll(role: kAXTextAreaRole)
+        let textFields = window.findAll(role: kAXTextFieldRole)
+
+        let inputField = textAreas.last ?? textFields.last
+
+        guard let input = inputField else {
+            print("Could not find message input field.")
+            print("Use 'kmsg inspect' to explore the window structure.")
+            throw ExitCode.failure
+        }
+
+        // Focus the input field
+        print("Focusing input field...")
+        do {
+            try input.focus()
+            Thread.sleep(forTimeInterval: 0.1)
+        } catch {
+            print("Warning: Could not focus input field: \(error)")
+        }
+
+        // Type the message using keyboard simulation
+        print("Typing message...")
+        typeText(message)
+
+        // Press Enter to send
+        Thread.sleep(forTimeInterval: 0.1)
+        print("Sending message...")
+        pressEnter()
+
+        print("✓ Message sent to '\(recipient)'")
+    }
+
+    private func typeText(_ text: String) {
+        // Use CGEvent to simulate keyboard input
+        let source = CGEventSource(stateID: .hidSystemState)
+
+        for char in text {
+            // For non-ASCII characters (like Korean), use the Unicode input method
+            let string = String(char)
+            if let event = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) {
+                var unicodeChars = Array(string.utf16)
+                event.keyboardSetUnicodeString(stringLength: unicodeChars.count, unicodeString: &unicodeChars)
+                event.post(tap: .cghidEventTap)
+            }
+            if let event = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
+                event.post(tap: .cghidEventTap)
+            }
+            // Small delay between characters
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+    }
+
+    private func pressEnter() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let enterKeyCode: CGKeyCode = 36 // Return key
+
+        if let keyDown = CGEvent(keyboardEventSource: source, virtualKey: enterKeyCode, keyDown: true) {
+            keyDown.post(tap: .cghidEventTap)
+        }
+        if let keyUp = CGEvent(keyboardEventSource: source, virtualKey: enterKeyCode, keyDown: false) {
+            keyUp.post(tap: .cghidEventTap)
+        }
+    }
+}

--- a/Sources/kmsg/Commands/StatusCommand.swift
+++ b/Sources/kmsg/Commands/StatusCommand.swift
@@ -1,0 +1,55 @@
+import ArgumentParser
+import Foundation
+
+struct StatusCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Check KakaoTalk and accessibility status"
+    )
+
+    @Flag(name: .long, help: "Show detailed information")
+    var verbose: Bool = false
+
+    func run() throws {
+        print("kmsg - KakaoTalk CLI Tool\n")
+
+        // Check accessibility permission
+        let hasPermission = AccessibilityPermission.isGranted()
+        print("Accessibility Permission: \(hasPermission ? "✓ Granted" : "✗ Not Granted")")
+
+        if !hasPermission {
+            print("")
+            AccessibilityPermission.printInstructions()
+            return
+        }
+
+        // Check KakaoTalk status
+        let isRunning = KakaoTalkApp.isRunning
+        print("KakaoTalk: \(isRunning ? "✓ Running" : "✗ Not Running")")
+
+        if !isRunning {
+            print("\nPlease launch KakaoTalk to continue.")
+            return
+        }
+
+        // Get detailed info if verbose
+        if verbose {
+            print("")
+            do {
+                let kakao = try KakaoTalkApp()
+                let windows = kakao.windows
+
+                print("Windows (\(windows.count)):")
+                for (index, window) in windows.enumerated() {
+                    let title = window.title ?? "(untitled)"
+                    let frame = window.frame.map { "(\(Int($0.origin.x)), \(Int($0.origin.y))) \(Int($0.size.width))x\(Int($0.size.height))" } ?? "unknown"
+                    print("  [\(index)] \(title) - \(frame)")
+                }
+            } catch {
+                print("Error accessing KakaoTalk: \(error)")
+            }
+        }
+
+        print("\n✓ Ready to use kmsg commands")
+    }
+}

--- a/Sources/kmsg/KakaoTalk/KakaoTalkApp.swift
+++ b/Sources/kmsg/KakaoTalk/KakaoTalkApp.swift
@@ -1,0 +1,128 @@
+import AppKit
+import Foundation
+
+/// Represents the KakaoTalk application and provides access to its UI elements
+public final class KakaoTalkApp: Sendable {
+    public static let bundleIdentifier = "com.kakao.KakaoTalkMac"
+
+    private let app: UIElement
+
+    public init() throws {
+        guard let runningApp = NSRunningApplication.runningApplications(
+            withBundleIdentifier: Self.bundleIdentifier
+        ).first else {
+            throw KakaoTalkError.appNotRunning
+        }
+
+        self.app = UIElement.application(pid: runningApp.processIdentifier)
+    }
+
+    // MARK: - App State
+
+    /// Check if KakaoTalk is currently running
+    public static var isRunning: Bool {
+        !NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).isEmpty
+    }
+
+    /// Get the running KakaoTalk application
+    public static var runningApplication: NSRunningApplication? {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first
+    }
+
+    /// Activate KakaoTalk (bring to foreground)
+    public func activate() {
+        Self.runningApplication?.activate()
+    }
+
+    // MARK: - Windows
+
+    /// Get all KakaoTalk windows
+    public var windows: [UIElement] {
+        app.windows
+    }
+
+    /// Get the main window (friends list)
+    public var mainWindow: UIElement? {
+        app.mainWindow
+    }
+
+    /// Get the focused window
+    public var focusedWindow: UIElement? {
+        app.focusedWindow
+    }
+
+    // MARK: - Window Discovery
+
+    /// Find a window by its title
+    public func findWindow(title: String) -> UIElement? {
+        windows.first { $0.title == title }
+    }
+
+    /// Find a window containing the given title substring
+    public func findWindow(titleContaining substring: String) -> UIElement? {
+        windows.first { $0.title?.contains(substring) == true }
+    }
+
+    /// Get the friends list window
+    public var friendsWindow: UIElement? {
+        // The main KakaoTalk window typically shows the user's name or "친구" in the title
+        mainWindow ?? windows.first
+    }
+
+    /// Get the chat list window
+    public var chatListWindow: UIElement? {
+        // Chat list might be a separate window or tab within main window
+        findWindow(titleContaining: "채팅") ?? mainWindow
+    }
+
+    // MARK: - UI Navigation
+
+    /// Get the application element for direct traversal
+    public var applicationElement: UIElement {
+        app
+    }
+
+    // MARK: - Debug
+
+    /// Print the UI hierarchy for debugging
+    public func printHierarchy(maxDepth: Int = 3) {
+        print("KakaoTalk UI Hierarchy:")
+        printElement(app, depth: 0, maxDepth: maxDepth)
+    }
+
+    private func printElement(_ element: UIElement, depth: Int, maxDepth: Int) {
+        guard depth <= maxDepth else { return }
+
+        let indent = String(repeating: "  ", count: depth)
+        print("\(indent)\(element.debugDescription)")
+
+        for child in element.children {
+            printElement(child, depth: depth + 1, maxDepth: maxDepth)
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum KakaoTalkError: Error, CustomStringConvertible {
+    case appNotRunning
+    case windowNotFound(String)
+    case elementNotFound(String)
+    case actionFailed(String)
+    case permissionDenied
+
+    public var description: String {
+        switch self {
+        case .appNotRunning:
+            return "KakaoTalk is not running. Please launch KakaoTalk first."
+        case .windowNotFound(let name):
+            return "Window not found: \(name)"
+        case .elementNotFound(let description):
+            return "UI element not found: \(description)"
+        case .actionFailed(let action):
+            return "Action failed: \(action)"
+        case .permissionDenied:
+            return "Accessibility permission denied. Please grant permission in System Settings."
+        }
+    }
+}

--- a/Sources/kmsg/kmsg.swift
+++ b/Sources/kmsg/kmsg.swift
@@ -1,0 +1,28 @@
+import ArgumentParser
+import Foundation
+
+@main
+struct Kmsg: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "kmsg",
+        abstract: "A CLI tool for KakaoTalk on macOS",
+        discussion: """
+            kmsg uses macOS Accessibility APIs to interact with KakaoTalk.
+
+            Before using kmsg, make sure:
+            1. KakaoTalk is installed and running
+            2. Accessibility permission is granted (System Settings > Privacy & Security > Accessibility)
+
+            Run 'kmsg status' to check if everything is set up correctly.
+            """,
+        version: "0.1.0",
+        subcommands: [
+            StatusCommand.self,
+            InspectCommand.self,
+            ChatsCommand.self,
+            SendCommand.self,
+            ReadCommand.self,
+        ],
+        defaultSubcommand: StatusCommand.self
+    )
+}


### PR DESCRIPTION
A command-line interface tool that uses macOS Accessibility APIs (AXUIElement) to interact with the KakaoTalk desktop application.

Features:
- status: Check KakaoTalk and accessibility permission status
- inspect: Debug UI hierarchy with configurable depth
- chats: List available chat rooms
- send: Send messages to chats (with dry-run option)
- read: Read messages from chat windows

The project uses Swift 6.0 with ArgumentParser for CLI handling. Includes a UIElement wrapper for AXUIElement providing a Swift-friendly API with attribute access, hierarchy traversal, and element search capabilities.

Requires macOS 13.0+ and accessibility permission to function.