### PR TITLE
Add Swift package foundation for KakaoTalk CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Xcode
+.DS_Store
+*.xcodeproj
+*.xcworkspace
+xcuserdata/
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved
+
+# IDE
+.idea/
+*.sublime-project
+*.sublime-workspace
+.vscode/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "kmsg",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "kmsg", targets: ["kmsg"]),
+        .library(name: "KakaoTalkAccessibility", targets: ["KakaoTalkAccessibility"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "kmsg",
+            dependencies: [
+                "KakaoTalkAccessibility",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
+        .target(
+            name: "KakaoTalkAccessibility",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "KakaoTalkAccessibilityTests",
+            dependencies: ["KakaoTalkAccessibility"]
+        )
+    ]
+)

--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -1,0 +1,62 @@
+# SHARED_TASK_NOTES
+
+## Current State
+
+Basic Swift package structure is complete and compiles:
+- `KakaoTalkAccessibility` library - wraps macOS Accessibility APIs
+- `kmsg` CLI executable - uses swift-argument-parser
+
+## Available Commands
+
+- `kmsg status` - checks accessibility permissions and KakaoTalk running state
+- `kmsg hierarchy` - prints the KakaoTalk UI element tree (for debugging)
+
+## Next Steps (Priority Order)
+
+1. **Analyze KakaoTalk UI structure** - Run `kmsg hierarchy` with KakaoTalk open to understand the element tree. This is essential before implementing the commands below.
+
+2. **Implement `friends` command** - List friends from the friend list tab
+   - Need to navigate to friend list tab
+   - Parse the list items
+
+3. **Implement `chats` command** - List chat rooms from the chat tab
+   - Need to navigate to chat tab
+   - Parse the chat room list
+
+4. **Implement `messages` command** - Read messages from a specific chat
+   - Need to open/find a specific chat room
+   - Parse message bubbles
+
+5. **Implement `send` command** - Send a message to a chat
+   - Find the text input field
+   - Enter text and press send
+
+## Technical Notes
+
+- KakaoTalk macOS bundle identifier: `com.kakao.KakaoTalkMac`
+- Uses `ApplicationServices` framework for AXUIElement APIs
+- User must grant accessibility permission in System Settings
+
+## Files Structure
+
+```
+Sources/
+  KakaoTalkAccessibility/
+    AccessibilityError.swift    # Error types
+    AccessibilityHelper.swift   # Low-level AX API helpers
+    KakaoTalkApp.swift          # High-level KakaoTalk wrapper
+    KakaoTalkAccessibility.swift # Module exports
+  kmsg/
+    Kmsg.swift                  # Main entry point
+    Commands/
+      StatusCommand.swift       # status subcommand
+      HierarchyCommand.swift    # hierarchy subcommand
+```
+
+## Running the Tool
+
+```bash
+swift build
+.build/debug/kmsg status
+.build/debug/kmsg hierarchy --depth 8
+```

--- a/Sources/KakaoTalkAccessibility/AccessibilityError.swift
+++ b/Sources/KakaoTalkAccessibility/AccessibilityError.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Errors that can occur when interacting with KakaoTalk via Accessibility APIs
+public enum AccessibilityError: LocalizedError {
+    case accessibilityNotEnabled
+    case kakaoTalkNotRunning
+    case kakaoTalkNotFound
+    case elementNotFound(String)
+    case actionFailed(String)
+    case timeout(String)
+    case unexpectedUIStructure(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .accessibilityNotEnabled:
+            return "Accessibility access is not enabled. Please enable it in System Settings > Privacy & Security > Accessibility."
+        case .kakaoTalkNotRunning:
+            return "KakaoTalk is not running. Please start KakaoTalk first."
+        case .kakaoTalkNotFound:
+            return "KakaoTalk application not found."
+        case .elementNotFound(let element):
+            return "UI element not found: \(element)"
+        case .actionFailed(let action):
+            return "Action failed: \(action)"
+        case .timeout(let operation):
+            return "Operation timed out: \(operation)"
+        case .unexpectedUIStructure(let description):
+            return "Unexpected UI structure: \(description)"
+        }
+    }
+}

--- a/Sources/KakaoTalkAccessibility/AccessibilityHelper.swift
+++ b/Sources/KakaoTalkAccessibility/AccessibilityHelper.swift
@@ -1,0 +1,208 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+/// Helper class for working with macOS Accessibility APIs
+public final class AccessibilityHelper {
+
+    /// Check if accessibility access is enabled for this application
+    public static func isAccessibilityEnabled() -> Bool {
+        let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true]
+        return AXIsProcessTrustedWithOptions(options)
+    }
+
+    /// Check accessibility status without prompting
+    public static func checkAccessibilityStatus() -> Bool {
+        return AXIsProcessTrusted()
+    }
+
+    /// Get the accessibility element for a running application by bundle identifier
+    public static func getApplicationElement(bundleIdentifier: String) throws -> AXUIElement {
+        guard let app = NSRunningApplication.runningApplications(
+            withBundleIdentifier: bundleIdentifier
+        ).first else {
+            throw AccessibilityError.kakaoTalkNotRunning
+        }
+
+        return AXUIElementCreateApplication(app.processIdentifier)
+    }
+
+    /// Get all windows for an application element
+    public static func getWindows(for app: AXUIElement) throws -> [AXUIElement] {
+        var windowsRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsRef)
+
+        guard result == .success, let windows = windowsRef as? [AXUIElement] else {
+            return []
+        }
+
+        return windows
+    }
+
+    /// Get the main window for an application element
+    public static func getMainWindow(for app: AXUIElement) throws -> AXUIElement? {
+        var mainWindowRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(app, kAXMainWindowAttribute as CFString, &mainWindowRef)
+
+        guard result == .success, let mainWindow = mainWindowRef else {
+            return nil
+        }
+
+        return (mainWindow as! AXUIElement)
+    }
+
+    /// Get the focused window for an application element
+    public static func getFocusedWindow(for app: AXUIElement) throws -> AXUIElement? {
+        var focusedWindowRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &focusedWindowRef)
+
+        guard result == .success, let focusedWindow = focusedWindowRef else {
+            return nil
+        }
+
+        return (focusedWindow as! AXUIElement)
+    }
+
+    /// Get an attribute value from an accessibility element
+    public static func getAttribute<T>(_ attribute: String, from element: AXUIElement) -> T? {
+        var valueRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef)
+
+        guard result == .success, let value = valueRef as? T else {
+            return nil
+        }
+
+        return value
+    }
+
+    /// Get the title of an accessibility element
+    public static func getTitle(of element: AXUIElement) -> String? {
+        return getAttribute(kAXTitleAttribute as String, from: element)
+    }
+
+    /// Get the value of an accessibility element
+    public static func getValue(of element: AXUIElement) -> String? {
+        return getAttribute(kAXValueAttribute as String, from: element)
+    }
+
+    /// Get the role of an accessibility element
+    public static func getRole(of element: AXUIElement) -> String? {
+        return getAttribute(kAXRoleAttribute as String, from: element)
+    }
+
+    /// Get the role description of an accessibility element
+    public static func getRoleDescription(of element: AXUIElement) -> String? {
+        return getAttribute(kAXRoleDescriptionAttribute as String, from: element)
+    }
+
+    /// Get the identifier of an accessibility element
+    public static func getIdentifier(of element: AXUIElement) -> String? {
+        return getAttribute(kAXIdentifierAttribute as String, from: element)
+    }
+
+    /// Get children of an accessibility element
+    public static func getChildren(of element: AXUIElement) -> [AXUIElement] {
+        return getAttribute(kAXChildrenAttribute as String, from: element) ?? []
+    }
+
+    /// Set the value of an accessibility element
+    public static func setValue(_ value: String, for element: AXUIElement) throws {
+        let result = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFTypeRef)
+
+        guard result == .success else {
+            throw AccessibilityError.actionFailed("Failed to set value")
+        }
+    }
+
+    /// Perform an action on an accessibility element
+    public static func performAction(_ action: String, on element: AXUIElement) throws {
+        let result = AXUIElementPerformAction(element, action as CFString)
+
+        guard result == .success else {
+            throw AccessibilityError.actionFailed("Failed to perform action: \(action)")
+        }
+    }
+
+    /// Press/click an element
+    public static func press(_ element: AXUIElement) throws {
+        try performAction(kAXPressAction as String, on: element)
+    }
+
+    /// Find children with a specific role
+    public static func findChildren(of element: AXUIElement, withRole role: String) -> [AXUIElement] {
+        let children = getChildren(of: element)
+        return children.filter { getRole(of: $0) == role }
+    }
+
+    /// Recursively find all elements matching a predicate
+    public static func findElements(
+        in element: AXUIElement,
+        matching predicate: (AXUIElement) -> Bool,
+        maxDepth: Int = 10
+    ) -> [AXUIElement] {
+        var results: [AXUIElement] = []
+
+        if predicate(element) {
+            results.append(element)
+        }
+
+        guard maxDepth > 0 else { return results }
+
+        let children = getChildren(of: element)
+        for child in children {
+            results.append(contentsOf: findElements(in: child, matching: predicate, maxDepth: maxDepth - 1))
+        }
+
+        return results
+    }
+
+    /// Find the first element matching a predicate
+    public static func findFirstElement(
+        in element: AXUIElement,
+        matching predicate: (AXUIElement) -> Bool,
+        maxDepth: Int = 10
+    ) -> AXUIElement? {
+        if predicate(element) {
+            return element
+        }
+
+        guard maxDepth > 0 else { return nil }
+
+        let children = getChildren(of: element)
+        for child in children {
+            if let found = findFirstElement(in: child, matching: predicate, maxDepth: maxDepth - 1) {
+                return found
+            }
+        }
+
+        return nil
+    }
+
+    /// Print the accessibility hierarchy for debugging
+    public static func printHierarchy(of element: AXUIElement, indent: Int = 0, maxDepth: Int = 5) {
+        guard maxDepth > 0 else { return }
+
+        let prefix = String(repeating: "  ", count: indent)
+        let role = getRole(of: element) ?? "unknown"
+        let title = getTitle(of: element)
+        let value = getValue(of: element)
+        let identifier = getIdentifier(of: element)
+
+        var description = "\(prefix)[\(role)]"
+        if let title = title, !title.isEmpty {
+            description += " title=\"\(title)\""
+        }
+        if let value = value, !value.isEmpty {
+            description += " value=\"\(value)\""
+        }
+        if let identifier = identifier, !identifier.isEmpty {
+            description += " id=\"\(identifier)\""
+        }
+        print(description)
+
+        let children = getChildren(of: element)
+        for child in children {
+            printHierarchy(of: child, indent: indent + 1, maxDepth: maxDepth - 1)
+        }
+    }
+}

--- a/Sources/KakaoTalkAccessibility/KakaoTalkAccessibility.swift
+++ b/Sources/KakaoTalkAccessibility/KakaoTalkAccessibility.swift
@@ -1,0 +1,10 @@
+/// KakaoTalkAccessibility - A Swift library for controlling KakaoTalk via macOS Accessibility APIs
+///
+/// This library provides programmatic access to KakaoTalk's UI elements, allowing you to:
+/// - List friends
+/// - List chat rooms
+/// - Read messages from a chat
+/// - Send messages to a chat
+
+// Re-export public types
+public typealias KakaoTalk = KakaoTalkApp

--- a/Sources/KakaoTalkAccessibility/KakaoTalkApp.swift
+++ b/Sources/KakaoTalkAccessibility/KakaoTalkApp.swift
@@ -1,0 +1,57 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+/// KakaoTalk bundle identifier
+public let kakaoTalkBundleIdentifier = "com.kakao.KakaoTalkMac"
+
+/// Main class for interacting with KakaoTalk via Accessibility APIs
+public final class KakaoTalkApp {
+    private let appElement: AXUIElement
+
+    /// Initialize with a running KakaoTalk instance
+    public init() throws {
+        guard AccessibilityHelper.checkAccessibilityStatus() else {
+            _ = AccessibilityHelper.isAccessibilityEnabled()
+            throw AccessibilityError.accessibilityNotEnabled
+        }
+
+        self.appElement = try AccessibilityHelper.getApplicationElement(bundleIdentifier: kakaoTalkBundleIdentifier)
+    }
+
+    /// Check if KakaoTalk is currently running
+    public static func isRunning() -> Bool {
+        return !NSRunningApplication.runningApplications(withBundleIdentifier: kakaoTalkBundleIdentifier).isEmpty
+    }
+
+    /// Activate KakaoTalk (bring to front)
+    public func activate() throws {
+        guard let app = NSRunningApplication.runningApplications(
+            withBundleIdentifier: kakaoTalkBundleIdentifier
+        ).first else {
+            throw AccessibilityError.kakaoTalkNotRunning
+        }
+        app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+    }
+
+    /// Get all windows
+    public func getWindows() throws -> [AXUIElement] {
+        return try AccessibilityHelper.getWindows(for: appElement)
+    }
+
+    /// Get the main window
+    public func getMainWindow() throws -> AXUIElement? {
+        return try AccessibilityHelper.getMainWindow(for: appElement)
+    }
+
+    /// Print the UI hierarchy for debugging
+    public func printUIHierarchy(maxDepth: Int = 5) throws {
+        print("=== KakaoTalk UI Hierarchy ===")
+        AccessibilityHelper.printHierarchy(of: appElement, maxDepth: maxDepth)
+    }
+
+    /// Get the raw application element for advanced operations
+    public var element: AXUIElement {
+        return appElement
+    }
+}

--- a/Sources/kmsg/Commands/HierarchyCommand.swift
+++ b/Sources/kmsg/Commands/HierarchyCommand.swift
@@ -1,0 +1,17 @@
+import ArgumentParser
+import Foundation
+import KakaoTalkAccessibility
+
+struct Hierarchy: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Print KakaoTalk's UI hierarchy for debugging"
+    )
+
+    @Option(name: .shortAndLong, help: "Maximum depth to traverse")
+    var depth: Int = 5
+
+    func run() throws {
+        let app = try KakaoTalkApp()
+        try app.printUIHierarchy(maxDepth: depth)
+    }
+}

--- a/Sources/kmsg/Commands/StatusCommand.swift
+++ b/Sources/kmsg/Commands/StatusCommand.swift
@@ -1,0 +1,47 @@
+import ArgumentParser
+import Foundation
+import KakaoTalkAccessibility
+
+struct Status: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Check KakaoTalk and accessibility status"
+    )
+
+    func run() throws {
+        print("Checking status...")
+        print()
+
+        // Check accessibility
+        let accessibilityEnabled = AccessibilityHelper.checkAccessibilityStatus()
+        if accessibilityEnabled {
+            print("[OK] Accessibility access is enabled")
+        } else {
+            print("[!] Accessibility access is NOT enabled")
+            print("    Please enable it in System Settings > Privacy & Security > Accessibility")
+            _ = AccessibilityHelper.isAccessibilityEnabled()
+        }
+
+        // Check if KakaoTalk is running
+        let isRunning = KakaoTalkApp.isRunning()
+        if isRunning {
+            print("[OK] KakaoTalk is running")
+        } else {
+            print("[!] KakaoTalk is NOT running")
+            print("    Please start KakaoTalk first")
+        }
+
+        // Try to connect if both checks pass
+        if accessibilityEnabled && isRunning {
+            print()
+            print("Attempting to connect to KakaoTalk...")
+            do {
+                let app = try KakaoTalkApp()
+                let windows = try app.getWindows()
+                print("[OK] Successfully connected to KakaoTalk")
+                print("     Found \(windows.count) window(s)")
+            } catch {
+                print("[!] Failed to connect: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Sources/kmsg/Kmsg.swift
+++ b/Sources/kmsg/Kmsg.swift
@@ -1,0 +1,25 @@
+import ArgumentParser
+import Foundation
+import KakaoTalkAccessibility
+
+@main
+struct Kmsg: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "kmsg",
+        abstract: "A CLI tool to interact with KakaoTalk via Accessibility APIs",
+        discussion: """
+            kmsg allows you to control KakaoTalk from the command line.
+
+            Before using this tool, make sure:
+            1. KakaoTalk is running
+            2. Accessibility access is granted to this application
+               (System Settings > Privacy & Security > Accessibility)
+            """,
+        version: "0.1.0",
+        subcommands: [
+            Status.self,
+            Hierarchy.self
+        ],
+        defaultSubcommand: Status.self
+    )
+}

--- a/Tests/KakaoTalkAccessibilityTests/AccessibilityHelperTests.swift
+++ b/Tests/KakaoTalkAccessibilityTests/AccessibilityHelperTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import KakaoTalkAccessibility
+
+final class AccessibilityHelperTests: XCTestCase {
+    func testAccessibilityStatusCheck() {
+        // This test just verifies the function can be called
+        // The actual result depends on system permissions
+        _ = AccessibilityHelper.checkAccessibilityStatus()
+    }
+
+    func testKakaoTalkRunningCheck() {
+        // This test just verifies the function can be called
+        // The actual result depends on whether KakaoTalk is running
+        _ = KakaoTalkApp.isRunning()
+    }
+}


### PR DESCRIPTION
Implement initial project structure for kmsg, a command-line tool to interact with KakaoTalk via macOS Accessibility APIs.

Core components:
- KakaoTalkAccessibility library: Wraps low-level AXUIElement APIs with AccessibilityHelper for common operations (finding elements, getting/setting attributes, performing actions) and KakaoTalkApp for high-level KakaoTalk-specific functionality
- kmsg CLI executable: Built with swift-argument-parser, currently supports 'status' and 'hierarchy' subcommands for checking permissions and debugging UI element trees

Package configuration targets macOS 13+ with Swift 5.9. Includes basic test scaffolding and project documentation outlining planned features (friends list, chat rooms, messages, send functionality).