### PR TITLE
fix: Correct chat list window detection and chat name parsing

### DIFF
--- a/Sources/kmsg/KakaoTalk/KakaoTalkApp.swift
+++ b/Sources/kmsg/KakaoTalk/KakaoTalkApp.swift
@@ -259,8 +259,17 @@ public final class KakaoTalkApp: Sendable {
 
     /// Get the chat list window
     public var chatListWindow: UIElement? {
-        // Chat list might be a separate window or tab within main window
-        findWindow(titleContaining: "채팅") ?? mainWindow
+        // KakaoTalk 26.x: the chat list window is titled "카카오톡"
+        // and contains navigation buttons with id "chatrooms" / "friends"
+        if let w = findWindow(titleContaining: "채팅") { return w }
+        if let w = findWindow(title: "카카오톡") { return w }
+        // Fallback: find the window containing the chatrooms navigation button
+        for window in windows {
+            if window.findFirst(identifier: "chatrooms") != nil {
+                return window
+            }
+        }
+        return mainWindow
     }
 
     // MARK: - UI Navigation


### PR DESCRIPTION
## Summary

- `chatListWindow`가 `findWindow(titleContaining: "채팅")`으로 찾지만 실제 윈도우 타이틀은 `"카카오톡"`이라 매칭 실패. 대화창이 반환되어 `chats`/`read`/`send` 전부 오동작
- `extractChatTitle`이 AXStaticText 중 읽지 않은 수 배지("7", "8")를 채팅방 이름으로 반환
- `extractLastMessage`가 KakaoTalk 26.x의 AXTextArea 구조를 인식 못함

## Changes

1. **`KakaoTalkApp.chatListWindow`**: `"카카오톡"` 타이틀 매칭 추가 + `chatrooms` 버튼 존재 여부로 fallback 탐지
2. **`ChatsCommand.run()`**: `ensureMainWindow` 대신 `chatListWindow`를 우선 사용
3. **`extractChatTitle`**: `Count Label` identifier, 시간값(HH:MM), 순수 숫자 필터링
4. **`extractLastMessage`**: AXTextArea에서 마지막 메시지 추출 (KakaoTalk 26.x)

## AX Tree Evidence (KakaoTalk 26.1.4)

채팅방 목록 Row 구조:
```
AXRow > AXCell
  AXButton (id: _NS:11)          ← 프로필
  AXStaticText (id: _NS:40)      ← 채팅방 이름 ✓
  AXStaticText (id: Count Label)  ← 읽지 않은 수 ("7") ← 기존 코드가 이걸 이름으로 반환
  AXStaticText (id: _NS:69)      ← 시간 ("17:35")
  AXScrollArea > AXTextArea       ← 마지막 메시지
```

## Test plan

- [ ] `kmsg chats` → 채팅방 이름 정상 표시 (숫자/시간 아닌 실제 이름)
- [ ] `kmsg read "채팅방이름" --trace-ax` → 검색 필드 발견 + 메시지 읽기
- [ ] `kmsg send "채팅방이름" "테스트" --dry-run` → 검색 필드 통해 채팅방 접근
- [ ] `kmsg cache warmup` → searchField 슬롯 정상 캐싱

Closes #5